### PR TITLE
Fixes empty <li> node in validation report if URI of sh:resultPath isn't using one of the base URIs 

### DIFF
--- a/.changeset/short-bobcats-cheat.md
+++ b/.changeset/short-bobcats-cheat.md
@@ -1,0 +1,6 @@
+---
+"shacl-playground": minor
+---
+
+- Fixes empty `<li>` node in validation report if URI of `sh:resultPath` isn't using one of the base URIs.
+- Also applies prefixed names to Focus Nodes in report summary

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -35,7 +35,7 @@
     "@vaadin/vaadin-split-layout": "21",
     "@vaadin/vaadin-tabs": "^21",
     "@vaadin/vaadin-text-field": "^21",
-    "@zazuko/rdf-vocabularies": "^2021.3.31",
+    "@zazuko/rdf-vocabularies": "^2023.1.19",
     "@zazuko/s": "^1.0.0",
     "@zazuko/shacl-playground": "^1.0.0",
     "clownface": "^1.2.0",

--- a/packages/app/src/lib/components/error-summary.js
+++ b/packages/app/src/lib/components/error-summary.js
@@ -18,7 +18,7 @@ function createMessage(result) {
 
 const renderResult = (result) => html` <li>${createMessage(result)}</li> `;
 
-function renderSummary({ focusNodes, ...top }) {
+function renderSummary({ focusNodes, ...top }, customPrefixes) {
   return html`
     <ul>
       ${top.errors.map(renderResult)}
@@ -31,7 +31,7 @@ function renderSummary({ focusNodes, ...top }) {
               ${[...properties].map(
                 ([property, messages]) => html`
                   <li>
-                    ${shrink(property.value)}:
+                    ${shrink(property.value, customPrefixes) == "" ? property.value : shrink(property.value, customPrefixes)}:
                     <ul>
                       ${messages.map(renderResult)}
                     </ul>
@@ -75,12 +75,14 @@ class ErrorSummary extends LitElement {
   static get properties() {
     return {
       validationResults: { type: Array },
+      customPrefixes: { type: Object },
     };
   }
 
   constructor() {
     super();
     this.validationResults = [];
+    this.customPrefixes = {};
   }
 
   render() {
@@ -93,7 +95,7 @@ class ErrorSummary extends LitElement {
         focusNodes: new TermMap(),
         errors: [],
       });
-      return renderSummary(summary);
+      return renderSummary(summary, this.customPrefixes);
     }
 
     return "";

--- a/packages/app/src/lib/validation-report.js
+++ b/packages/app/src/lib/validation-report.js
@@ -38,7 +38,7 @@ class ValidationReport extends connect(store, LitElement) {
     switch (this.displayAs) {
       case "tree":
         return html`
-          <error-summary .validationResults="${this.results}"></error-summary>
+          <error-summary .validationResults="${this.results}" .customPrefixes="${this.customPrefixes}"></error-summary>
         `;
       case "raw": {
         import("@rdfjs-elements/rdf-snippet");
@@ -69,6 +69,7 @@ class ValidationReport extends connect(store, LitElement) {
         ...state.shapesGraph.prefixes,
         ...state.dataGraph.prefixes,
       ].join(","),
+      customPrefixes: { ...state.shapesGraph.customPrefixes, ...state.dataGraph.customPrefixes }
     };
   }
 }


### PR DESCRIPTION
🛠️ packages/app/package.json -> Updated version of "@zazuko/rdf-vocabularies" from "^2021.3.31" to "^2023.1.19".

🛠️ packages/app/src/lib/components/error-summary.js -> Added a new parameter "customPrefixes" to the function "renderSummary". Also, added a new property "customPrefixes" to the class "ErrorSummary" and updated the "render" method to pass "customPrefixes" to "renderSummary".  The updated version of the shrink method now allows to pass custom prefixes. In case no match was found; the whole URI will be returned (instead of no value at all)

🛠️ packages/app/src/lib/validation-report.js -> Passed "customPrefixes" to the "error-summary" component in the "render" method of the class "ValidationReport". Also, updated the "stateChanged" method to include "customPrefixes" in the returned object.

Before:
![image](https://github.com/zazuko/shacl-playground/assets/10495449/37514313-4e69-48bd-8aa1-65ef79595bc7)

After:
![image](https://github.com/zazuko/shacl-playground/assets/10495449/2f3bfe82-8b5e-492f-a395-9a302acdec66)
