### PR TITLE
Listen to all tags for `gh-pages` workflow

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -2,7 +2,8 @@ name: GitHub Pages
 
 on:
   push:
-    tags: ["*"]
+    tags:
+      - "**"
 
 jobs:
   publish:


### PR DESCRIPTION
Configure the `gh-pages` GitHub Actions workflow to listen to all tags, including the ones that contain slashes.