### PR TITLE
Configure Dependabot

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+* @tpluscode
+/.github/  @ludovicm67

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# Documentation: https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    # Workflow files stored in the default location of `.github/workflows`. (You don't need to specify `/.github/workflows` for `directory`. You can use `directory: "/"`.)
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  # Maintain dependencies for npm
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
I saw that we have many GitHub Actions that are not up-to-date.

This PR configures Dependabot for GitHub Actions and for node.
I created a CODEOWNERS file to make sure there is someone that gets assigned as reviewer to each PR created by Dependabot.

@tpluscode I added you as default CODEOWNERS, so that you can watch changes for code and NPM dependencies upgrades.

I will take care of everything related to GitHub Actions if it's OK for you?