### PR TITLE
Create Dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      polymer:
+        patterns:
+          - "@polymer/*"
+      vaadin:
+        patterns:
+          - "@vaadin/*"


### PR DESCRIPTION
Having Dependabot creating PRs for updating dependencies is useful to make sure that everything is up-to-date and let us know if something is breaking at a specific version.
But it also creates a lot of PRs that takes time to review.
We can improve the setup by regrouping some dependency upgrades in a single PR, like all the `@vaadin/*` and `@polymer/*` modules ; this is what this PR is doing.